### PR TITLE
fix: bail out of dictionary/array parse loops on non-advancing offset

### DIFF
--- a/src/Process/RawObject.php
+++ b/src/Process/RawObject.php
@@ -239,9 +239,17 @@ abstract class RawObject
             // get array content
             $objval = [];
             do {
+                $oldoffset = $offset;
                 $element = $this->getRawObject($offset);
                 $offset = $element[2];
                 $objval[] = $element; // @phpstan-ignore parameterByRef.type
+                // Bail out if getRawObject failed to advance $offset (a byte
+                // processDefault() could not consume): without this guard the
+                // loop spins forever on the same offset and exhausts PHP memory.
+                // Mirrors the existing guard in Parser::getRawIndirectObject().
+                if ((int) $offset === (int) $oldoffset) {
+                    break;
+                }
             } while ($element[0] !== ']');
 
             if (\count($objval) > 0) {
@@ -269,9 +277,17 @@ abstract class RawObject
                 // get array content
                 $objval = [];
                 do {
+                    $oldoffset = $offset;
                     $element = $this->getRawObject($offset);
                     $offset = $element[2];
                     $objval[] = $element; // @phpstan-ignore parameterByRef.type
+                    // Bail out if getRawObject failed to advance $offset (a byte
+                    // processDefault() could not consume): without this guard the
+                    // loop spins forever on the same offset and exhausts PHP memory.
+                    // Mirrors the existing guard in Parser::getRawIndirectObject().
+                    if ((int) $offset === (int) $oldoffset) {
+                        break;
+                    }
                 } while ($element[0] !== '>>');
 
                 if (\count($objval) > 0) {

--- a/test/ParserHarness.php
+++ b/test/ParserHarness.php
@@ -56,6 +56,8 @@ class ParserHarness extends Parser
 
     private bool $useParentIndirect = false;
 
+    private bool $useParentRawObject = false;
+
     /**
      * @param array{
      *        'trailer': array{
@@ -217,6 +219,25 @@ class ParserHarness extends Parser
     }
 
     /**
+     * Test-only: bypass the queue override below and run the real inherited
+     * getRawObject against `$this->pdfdata`. Lets tests exercise the real
+     * processAngular / processBracket loops with arbitrary byte input.
+     *
+     * @return RawObjectArray
+     *
+     * @throws \Com\Tecnick\Pdf\Parser\Exception
+     */
+    public function callParentGetRawObject(int $offset = 0): array
+    {
+        $this->useParentRawObject = true;
+        try {
+            return $this->getRawObject($offset);
+        } finally {
+            $this->useParentRawObject = false;
+        }
+    }
+
+    /**
      * @param array{
      *        'trailer'?: array{
      *            'encrypt'?: string,
@@ -266,6 +287,10 @@ class ParserHarness extends Parser
      */
     protected function getRawObject(int $offset = 0): array
     {
+        if ($this->useParentRawObject) {
+            return parent::getRawObject($offset);
+        }
+
         if (empty($this->rawObjectQueue)) {
             return ['endobj', 'endobj', $offset];
         }

--- a/test/ParserProcessingTest.php
+++ b/test/ParserProcessingTest.php
@@ -403,4 +403,49 @@ class ParserProcessingTest extends TestCase
         $params = $parser->getDecodeParmsPublic($sdic, 0);
         $this->assertSame(['Valid' => 7], $params);
     }
+
+    /**
+     * Regression: processAngular() must bail out when getRawObject() fails
+     * to advance $offset, rather than spinning forever and exhausting PHP
+     * memory. Without the guard, the inner do-while loop accumulates
+     * identical zero-length tokens at the same offset until OOM.
+     *
+     * @throws \Com\Tecnick\Pdf\Parser\Exception
+     */
+    public function testProcessAngularBailsOnNonAdvancingByte(): void
+    {
+        // `<<` then `~` — a byte that processDefault() cannot consume — and
+        // no `>>` terminator. Before the fix this hangs / OOMs in
+        // RawObject::processAngular() at the inner do-while loop.
+        $parser = new ParserHarness();
+        $parser->setPdfDataPublic('<<~');
+
+        $element = $parser->callParentGetRawObject(0);
+
+        $this->assertIsArray($element);
+        $this->assertSame('<<', $element[0]);
+        $this->assertIsArray($element[1]);
+        // The non-advancing guard must short-circuit within a single
+        // iteration; the trailing array_pop then leaves $objval empty.
+        $this->assertLessThan(5, \count($element[1]));
+    }
+
+    /**
+     * Regression: processBracket() must bail out on a non-advancing parse,
+     * for the same reasons as the dictionary loop above.
+     *
+     * @throws \Com\Tecnick\Pdf\Parser\Exception
+     */
+    public function testProcessBracketBailsOnNonAdvancingByte(): void
+    {
+        $parser = new ParserHarness();
+        $parser->setPdfDataPublic('[~');
+
+        $element = $parser->callParentGetRawObject(0);
+
+        $this->assertIsArray($element);
+        $this->assertSame('[', $element[0]);
+        $this->assertIsArray($element[1]);
+        $this->assertLessThan(5, \count($element[1]));
+    }
 }


### PR DESCRIPTION
# Description

Found this while re-importing PDFs that embed a TrueTypeUnicode (CIDFontType2 / Type0) font via the downstream `tc-lib-pdf` `setImportSourceData()` path. PHP errors out with an unbounded memory allocation:

PHP Fatal error: Allowed memory size of N bytes exhausted in
.../tc-lib-pdf-parser/src/Process/RawObject.php on line 274


This specifically happened when trying to use the USPSIMBCompact TTF.

Increasing `memory_limit` doesn't help — the parser produces increasingly large arrays of empty tokens at the same byte offset, so the leak is unbounded.

Root cause: `RawObject::processAngular()` (lines 271–275) and `RawObject::processBracket()` (lines 241–245) walk dictionary and array contents with

```php
do {
    $element = $this->getRawObject($offset);
    $offset = $element[2];
    $objval[] = $element;
} while ($element[0] !== '>>');   // or '!== ']'' for processBracket
```

Neither inner loop guards against a non-advancing parse. When getRawObject() reaches a byte it cannot classify (not whitespace, not %, not in SYMBOLMETHOD, no keyword/numeric match in processDefault()), it returns ['', '', $sameOffset] — $offset is unchanged and $element[0] is '', which is neither '>>' nor ']'. The loop re-runs at the same offset forever, accumulating identical empty tokens until PHP OOMs.
  
`Parser::getRawIndirectObject()` (lines 170–192) already uses the right guard pattern:

```php
do {
    $oldoffset = $offset;
    $element = $this->getRawObject($offset);
    $offset = $element[2];
    // ...
} while ($element[0] !== 'endobj' && (int) $offset !== (int) $oldoffset);
```

This PR applies the same guard at the two missing call sites.

```php  
do {
    $oldoffset = $offset;
    $element = $this->getRawObject($offset);
    $offset = $element[2];
    $objval[] = $element;
    if ((int) $offset === (int) $oldoffset) {
        // Bail out instead of spinning forever; mirrors the guard already
        // in Parser::getRawIndirectObject().
        break;
    }
} while ($element[0] !== '>>');   // and likewise '!== ']'' for processBracket
```

On a non-advancing iteration the loop breaks; the trailing `\array_pop($objval)` then removes the empty token we just appended, leaving the partial dictionary/array intact for the outer parser to handle. Behavior matches `getRawIndirectObject()` exactly.


## Checklist:

- [x] The `make buildall` command has been run successfully without any error or warning.
- [x] Any new code line is covered by unit tests and the coverage has not dropped (`testProcessAngularBailsOnNonAdvancingByte`, `testProcessBracketBailsOnNonAdvancingByte`).
- [x] Any new code follows the style guidelines of this project.
- [x] The code changes have been self-reviewed.
- [x] Corresponding changes to the documentation have been made.
- [ ] The version has been updated in the VERSION file.

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue) → The patch number in the VERSION file has been increased.
- [ ] New feature (non-breaking change which adds functionality) → The minor number in the VERSION file has been increased.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) → The major number in the VERSION file has been increased.
- [ ] Automation.
- [ ] Documentation.
- [ ] Example.
- [ ] Testing.
